### PR TITLE
Fix stylesheet urls and duplicate ids in manifest

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -731,6 +731,7 @@
         return mimeTypes[ext] || 'application/octet-stream';
     }
     function makePackage(oebps, assetRegistry){
+        const idStore = [];
         const doc = document.implementation.createDocument(
             'http://www.idpf.org/2007/opf', // default namespace
             'package', // root element name
@@ -818,7 +819,12 @@
         let components = getBookComponents();
         components.forEach(chapter =>{
             const item = doc.createElementNS('http://www.idpf.org/2007/opf', 'item');
-            item.setAttribute('id', chapter.meta.id);
+            let id = chapter.meta.id;
+            if (idStore.includes(id)) {
+              id = id + "-" + crypto.randomUUID();
+            }
+            item.setAttribute('id', id);
+            idStore.push(id);
             item.setAttribute('href', truncate(chapter.meta.path));
             item.setAttribute('media-type', 'application/xhtml+xml');
             manifest.appendChild(item);
@@ -833,7 +839,12 @@
         assetRegistry.forEach(asset => {
             const item = doc.createElementNS('http://www.idpf.org/2007/opf', 'item');
             let aname = asset.startsWith("http") ? getFilenameFromURL(asset) : asset;
-            item.setAttribute('id', aname.split(".")[0]);
+            let id = aname.split(".")[0];
+            if (idStore.includes(id)) {
+              id = id + "-" + crypto.randomUUID();
+            }
+            item.setAttribute('id', id);
+            idStore.push(id);
             item.setAttribute('href', aname);
             item.setAttribute('media-type', getMimeTypeFromFileName(aname));
             manifest.appendChild(item);

--- a/userscript.js
+++ b/userscript.js
@@ -682,8 +682,12 @@
         }
 
         for (let link of links){
+            let src = link;
+            if (!(src.startsWith("http://") || src.startsWith("https://"))) {
+              src = (new URL(src, new URL(url))).toString();
+            }
             let linkElement = doc.createElement('link');
-            linkElement.setAttribute("href", link);
+            linkElement.setAttribute("href", truncate(src));
             linkElement.setAttribute("rel", "stylesheet");
             linkElement.setAttribute("type", "text/css");
             head.appendChild(linkElement);

--- a/userscript.js
+++ b/userscript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          LibreGRAB
 // @namespace     http://tampermonkey.net/
-// @version       2025-03-25
+// @version       2025-03-27
 // @description   Download all the booty!
 // @author        PsychedelicPalimpsest
 // @license       MIT


### PR DESCRIPTION
Since the ids of the content.opf entries are based on the filenames. When it simply strips off the extension to use as the ID it can cause a duplicate problem. One book I had had files named butcher_1.xhtml and an image butcher_1.jpg. The book was causing my reader to hang. When I looked at it with an editor I noticed it was resolving the image jpeg as a text document page. So it was failing to parse as xml.

I also noticed the fonts didn't look how they looked on Libby's page. Which was due to the xhtml in the epub file having the full url and not the local reference for the epub file. Thus the truncation is necessary.